### PR TITLE
Feat/#10 - WebView 연동

### DIFF
--- a/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
+++ b/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		873E9C872CD11F3D0015FB45 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C862CD11F3D0015FB45 /* ButtonStyle.swift */; };
 		873E9C892CD137A50015FB45 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C882CD137A50015FB45 /* View+.swift */; };
 		873E9C8C2CD13D710015FB45 /* PTColorText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C8B2CD13D710015FB45 /* PTColorText.swift */; };
+		873E9C922CD14A870015FB45 /* PTWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C912CD14A870015FB45 /* PTWebView.swift */; };
 		8754676D2CC3C57A00144BE3 /* HeaderTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */; };
 		87E1E9F92CC41D61006FAA24 /* ProximityClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E1E9F82CC41D61006FAA24 /* ProximityClient.swift */; };
 		87E1E9FC2CC4C529006FAA24 /* HapticClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E1E9FB2CC4C528006FAA24 /* HapticClient.swift */; };
@@ -104,6 +105,7 @@
 		873E9C862CD11F3D0015FB45 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		873E9C882CD137A50015FB45 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		873E9C8B2CD13D710015FB45 /* PTColorText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTColorText.swift; sourceTree = "<group>"; };
+		873E9C912CD14A870015FB45 /* PTWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTWebView.swift; sourceTree = "<group>"; };
 		8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTabFeature.swift; sourceTree = "<group>"; };
 		87E1E9F82CC41D61006FAA24 /* ProximityClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityClient.swift; sourceTree = "<group>"; };
 		87E1E9FB2CC4C528006FAA24 /* HapticClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticClient.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				8717B5F02CC1FB3000542061 /* Statistics */,
 				8717B5F12CC1FB3D00542061 /* Ranking */,
 				8717B5F22CC1FB4900542061 /* Setting */,
+				873E9C902CD14A7A0015FB45 /* Web */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -398,6 +401,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		873E9C902CD14A7A0015FB45 /* Web */ = {
+			isa = PBXGroup;
+			children = (
+				873E9C912CD14A870015FB45 /* PTWebView.swift */,
+			);
+			path = Web;
+			sourceTree = "<group>";
+		};
 		8754676E2CC3DAAA00144BE3 /* HeaderTab */ = {
 			isa = PBXGroup;
 			children = (
@@ -493,6 +504,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				873E9C922CD14A870015FB45 /* PTWebView.swift in Sources */,
 				873E9C8C2CD13D710015FB45 /* PTColorText.swift in Sources */,
 				8735D7362CC25C7A00C7824C /* PushUp.swift in Sources */,
 				871059E72CC3B1F500C4362D /* ConsistencyRankingFeature.swift in Sources */,

--- a/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
+++ b/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		8735D7412CC2779600C7824C /* SettingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7402CC2779600C7824C /* SettingFeature.swift */; };
 		8735D7432CC279DA00C7824C /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7422CC279DA00C7824C /* SettingView.swift */; };
 		8735D7452CC27A2200C7824C /* RankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7442CC27A2200C7824C /* RankingView.swift */; };
-		8735D7472CC27A4900C7824C /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7462CC27A4900C7824C /* StatisticsView.swift */; };
+		8735D7472CC27A4900C7824C /* PTWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7462CC27A4900C7824C /* PTWebView.swift */; };
 		8735D74A2CC27C7E00C7824C /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D7492CC27C7E00C7824C /* MainTabView.swift */; };
 		8735D74C2CC27C8C00C7824C /* MainFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D74B2CC27C8C00C7824C /* MainFeature.swift */; };
 		8735D74E2CC27CD800C7824C /* MainScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8735D74D2CC27CD800C7824C /* MainScene.swift */; };
@@ -52,7 +52,9 @@
 		873E9C872CD11F3D0015FB45 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C862CD11F3D0015FB45 /* ButtonStyle.swift */; };
 		873E9C892CD137A50015FB45 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C882CD137A50015FB45 /* View+.swift */; };
 		873E9C8C2CD13D710015FB45 /* PTColorText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C8B2CD13D710015FB45 /* PTColorText.swift */; };
-		873E9C922CD14A870015FB45 /* PTWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C912CD14A870015FB45 /* PTWebView.swift */; };
+		873E9C922CD14A870015FB45 /* PTWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C912CD14A870015FB45 /* PTWebViewController.swift */; };
+		873E9C942CD210C10015FB45 /* PTWebFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C932CD210C10015FB45 /* PTWebFeature.swift */; };
+		873E9C962CD462E00015FB45 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873E9C952CD462E00015FB45 /* StatisticsView.swift */; };
 		8754676D2CC3C57A00144BE3 /* HeaderTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */; };
 		87E1E9F92CC41D61006FAA24 /* ProximityClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E1E9F82CC41D61006FAA24 /* ProximityClient.swift */; };
 		87E1E9FC2CC4C529006FAA24 /* HapticClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E1E9FB2CC4C528006FAA24 /* HapticClient.swift */; };
@@ -85,7 +87,7 @@
 		8735D7402CC2779600C7824C /* SettingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingFeature.swift; sourceTree = "<group>"; };
 		8735D7422CC279DA00C7824C /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		8735D7442CC27A2200C7824C /* RankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingView.swift; sourceTree = "<group>"; };
-		8735D7462CC27A4900C7824C /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
+		8735D7462CC27A4900C7824C /* PTWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTWebView.swift; sourceTree = "<group>"; };
 		8735D7492CC27C7E00C7824C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		8735D74B2CC27C8C00C7824C /* MainFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFeature.swift; sourceTree = "<group>"; };
 		8735D74D2CC27CD800C7824C /* MainScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScene.swift; sourceTree = "<group>"; };
@@ -105,7 +107,9 @@
 		873E9C862CD11F3D0015FB45 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		873E9C882CD137A50015FB45 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		873E9C8B2CD13D710015FB45 /* PTColorText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTColorText.swift; sourceTree = "<group>"; };
-		873E9C912CD14A870015FB45 /* PTWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTWebView.swift; sourceTree = "<group>"; };
+		873E9C912CD14A870015FB45 /* PTWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTWebViewController.swift; sourceTree = "<group>"; };
+		873E9C932CD210C10015FB45 /* PTWebFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTWebFeature.swift; sourceTree = "<group>"; };
+		873E9C952CD462E00015FB45 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 		8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTabFeature.swift; sourceTree = "<group>"; };
 		87E1E9F82CC41D61006FAA24 /* ProximityClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityClient.swift; sourceTree = "<group>"; };
 		87E1E9FB2CC4C528006FAA24 /* HapticClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticClient.swift; sourceTree = "<group>"; };
@@ -228,7 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				8735D73C2CC276F400C7824C /* StatisticsFeature.swift */,
-				8735D7462CC27A4900C7824C /* StatisticsView.swift */,
+				873E9C952CD462E00015FB45 /* StatisticsView.swift */,
 			);
 			path = Statistics;
 			sourceTree = "<group>";
@@ -404,7 +408,9 @@
 		873E9C902CD14A7A0015FB45 /* Web */ = {
 			isa = PBXGroup;
 			children = (
-				873E9C912CD14A870015FB45 /* PTWebView.swift */,
+				873E9C912CD14A870015FB45 /* PTWebViewController.swift */,
+				8735D7462CC27A4900C7824C /* PTWebView.swift */,
+				873E9C932CD210C10015FB45 /* PTWebFeature.swift */,
 			);
 			path = Web;
 			sourceTree = "<group>";
@@ -504,12 +510,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				873E9C922CD14A870015FB45 /* PTWebView.swift in Sources */,
+				873E9C922CD14A870015FB45 /* PTWebViewController.swift in Sources */,
 				873E9C8C2CD13D710015FB45 /* PTColorText.swift in Sources */,
 				8735D7362CC25C7A00C7824C /* PushUp.swift in Sources */,
 				871059E72CC3B1F500C4362D /* ConsistencyRankingFeature.swift in Sources */,
 				8735D74A2CC27C7E00C7824C /* MainTabView.swift in Sources */,
-				8735D7472CC27A4900C7824C /* StatisticsView.swift in Sources */,
+				8735D7472CC27A4900C7824C /* PTWebView.swift in Sources */,
 				87E1E9F92CC41D61006FAA24 /* ProximityClient.swift in Sources */,
 				8735D7262CC21A8000C7824C /* Int+.swift in Sources */,
 				873E9C892CD137A50015FB45 /* View+.swift in Sources */,
@@ -521,6 +527,7 @@
 				8735D7432CC279DA00C7824C /* SettingView.swift in Sources */,
 				8717B5F42CC1FD6B00542061 /* WorkoutFeature.swift in Sources */,
 				8735D7602CC39E8200C7824C /* DTO.swift in Sources */,
+				873E9C942CD210C10015FB45 /* PTWebFeature.swift in Sources */,
 				8735D7572CC371F100C7824C /* RankingDetailView.swift in Sources */,
 				8735D73D2CC276F400C7824C /* StatisticsFeature.swift in Sources */,
 				8735D7512CC27EF800C7824C /* OnboardingFeature.swift in Sources */,
@@ -531,6 +538,7 @@
 				8735D75D2CC398E500C7824C /* StatisticsClient.swift in Sources */,
 				8735D7392CC2767000C7824C /* RootFeature.swift in Sources */,
 				871059EB2CC3B26300C4362D /* RankingType.swift in Sources */,
+				873E9C962CD462E00015FB45 /* StatisticsView.swift in Sources */,
 				8735D7322CC2557B00C7824C /* Workout.swift in Sources */,
 				871059ED2CC3BBEE00C4362D /* HeaderTabView.swift in Sources */,
 				8735D74C2CC27C8C00C7824C /* MainFeature.swift in Sources */,

--- a/PhysicalTrack/PhysicalTrack/App/PhysicalTrackApp.swift
+++ b/PhysicalTrack/PhysicalTrack/App/PhysicalTrackApp.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 @main
 struct PhysicalTrackApp: App {
     let store = Store(initialState: RootFeature.State()) {
-        RootFeature()._printChanges()
+        RootFeature()
     }
     var body: some Scene {
         WindowGroup {

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingFeatrue.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingFeatrue.swift
@@ -36,7 +36,7 @@ struct RankingFeature {
     @Reducer
     enum Path {
         case rankingDetail(RankingDetailFeature)
-        case statistics(StatisticsFeature)
+        case web(PTWebFeature)
     }
     
 
@@ -61,7 +61,7 @@ struct RankingFeature {
                 state.path.append(.rankingDetail(RankingDetailFeature.State(type, state.ranking)))
                 return .none
             case let .path(.element(id: _, action: .rankingDetail(.rankCellTapped(userID)))):
-                state.path.append(.statistics(StatisticsFeature.State(userID)))
+                state.path.append(.web(PTWebFeature.State(url: "https://physical-t-7jce.vercel.app")))
                 return .none
                 
             case let .rankingResponse(.success(response)):

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
@@ -66,12 +66,12 @@ struct RankingView: View {
             }
         } destination: { store in
             switch store.case {
-            case .statistics(let store):
-                StatisticsView(store: store)
-            case .rankingDetail(let store):
+            case let .rankingDetail(store):
                 RankingDetailView(store: store)
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar(.hidden, for: .tabBar)
+            case let .web(store):
+                PTWebView(store: store)
             }
         }
        

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailFeature.swift
@@ -34,6 +34,7 @@ struct RankingDetailFeature {
         case pushUp(PushUpRankingFeature.Action)
         case headerTab(HeaderTabFeature<RankingType>.Action)
         case rankCellTapped(Int)
+        case path
     }
     
     var body: some ReducerOf<Self> {

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailView.swift
@@ -23,12 +23,17 @@ struct RankingDetailView: View {
                 if let store = store.scope(state: \.consistency, action: \.consistency) {
                     LazyVStack {
                         ForEach(store.ranking, id: \.self) { data in
-                            HStack {
-                                Text(String(data.rank))
-                                Text(data.name)
-                                Spacer()
-                                Text(String(data.daysActive))
+                            Button {
+                                store.send(.rankCellTapped(1))
+                            } label: {
+                                HStack {
+                                    Text(String(data.rank))
+                                    Text(data.name)
+                                    Spacer()
+                                    Text(String(data.daysActive))
+                                }
                             }
+                            
                         }
                     }
                     .padding(.horizontal, 40)
@@ -38,12 +43,17 @@ struct RankingDetailView: View {
                 if let store = store.scope(state: \.pushUp, action: \.pushUp) {
                     LazyVStack {
                         ForEach(store.ranking, id: \.self) { data in
-                            HStack {
-                                Text(String(data.rank))
-                                Text(data.name)
-                                Spacer()
-                                Text(String(data.quantity))
+                            Button {
+                                store.send(.rankCellTapped(1))
+                            } label: {
+                                HStack {
+                                    Text(String(data.rank))
+                                    Text(data.name)
+                                    Spacer()
+                                    Text(String(data.quantity))
+                                }
                             }
+                
                         }
                     }
                     .padding(.horizontal, 40)

--- a/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsFeature.swift
@@ -14,19 +14,28 @@ struct StatisticsFeature {
     @ObservableState
     struct State {
         private var _userID: Int
+        var web: PTWebFeature.State?
         
         init(_ userID: Int = 1) {
             self._userID = userID
+            self.web = .init(url: "https://physical-t-7jce.vercel.app")
         }
+        
     }
     
     enum Action {
-        
+        case web(PTWebFeature.Action)
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state , action in
-            return .none
+            switch action {
+            case .web:
+                return .none
+            }
+        }
+        .ifLet(\.web, action: \.web) {
+            PTWebFeature()
         }
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
@@ -10,9 +10,19 @@ import ComposableArchitecture
 
 struct StatisticsView: View {
     let store : StoreOf<StatisticsFeature>
+    let webView = SMWebView(url: "https://physical-t-7jce.vercel.app")
     
     var body: some View {
-        SMWebView(url: "https://physical-t-p3n2.vercel.app")
+        VStack {
+            HStack {
+                Button("쿠키 확인") {
+                    webView.printCookie()
+                }
+            }
+            
+            webView
+            
+        }
             
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
@@ -2,35 +2,25 @@
 //  StatisticsView.swift
 //  PhysicalTrack
 //
-//  Created by 장석우 on 10/18/24.
+//  Created by 장석우 on 11/1/24.
 //
 
 import SwiftUI
 import ComposableArchitecture
 
 struct StatisticsView: View {
-    let store : StoreOf<StatisticsFeature>
-    let webView = SMWebView(url: "https://physical-t-7jce.vercel.app")
+    
+    @Bindable var store: StoreOf<StatisticsFeature>
     
     var body: some View {
-        VStack {
-            HStack {
-                Button("쿠키 확인") {
-                    webView.printCookie()
-                }
-            }
-            
-            webView
-            
+        if let store = store.scope(state: \.web, action: \.web) {
+            PTWebView(store: store)
         }
-            
     }
 }
 
 #Preview {
-    StatisticsView(
-        store: .init(initialState: StatisticsFeature.State()) {
-            StatisticsFeature()
-        }
-    )
+    StatisticsView(store: .init(initialState: StatisticsFeature.State(), reducer: {
+        StatisticsFeature()
+    }))
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
@@ -12,7 +12,8 @@ struct StatisticsView: View {
     let store : StoreOf<StatisticsFeature>
     
     var body: some View {
-        Text("Statistics")
+        SMWebView(url: "https://physical-t-p3n2.vercel.app")
+            
     }
 }
 

--- a/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Statistics/StatisticsView.swift
@@ -13,8 +13,10 @@ struct StatisticsView: View {
     @Bindable var store: StoreOf<StatisticsFeature>
     
     var body: some View {
-        if let store = store.scope(state: \.web, action: \.web) {
-            PTWebView(store: store)
+        NavigationStack {
+            if let store = store.scope(state: \.web, action: \.web) {
+                PTWebView(store: store)
+            }
         }
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebFeature.swift
@@ -1,0 +1,87 @@
+//
+//  PTWebFeature.swift
+//  PhysicalTrack
+//
+//  Created by 장석우 on 10/30/24.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct PTWebFeature {
+    
+    @ObservableState
+    struct State: Equatable {
+        var url: String
+        var isLoading: Bool = false
+        var webViewController: PTWebViewController?
+        
+        init(url: String) {
+            self.url = url
+        }
+    }
+    
+    enum Action: Equatable {
+        case onAppear
+        case reload
+        case setCookies
+        case goBack
+    }
+    
+    @Dependency(\.dismiss) var dismiss
+    var body: some ReducerOf<Self> {
+        Reduce { state , action in
+            switch action {
+            case .onAppear:
+                state.webViewController = PTWebViewController()
+                return .concatenate(
+                    
+                    .send(.setCookies),
+                    .run { [url = state.url, webVC = state.webViewController] _ in
+                        guard let url = URL(string: url) else { return }
+                        await webVC?.load(with: url)
+                    }
+                )
+                
+            case .setCookies:
+                return .run { [webVC = state.webViewController] _ in
+                    let cookies = [
+                        [
+                            HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
+                            HTTPCookiePropertyKey.name: "access_token",
+                            HTTPCookiePropertyKey.path: "/",
+                            HTTPCookiePropertyKey.value: "stub_access_token",
+                            HTTPCookiePropertyKey.secure: "TRUE",
+                            HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24)
+                        ],
+                        [
+                            HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
+                            HTTPCookiePropertyKey.name: "user_id",
+                            HTTPCookiePropertyKey.path: "/",
+                            HTTPCookiePropertyKey.value: "stub_user_id",
+                            HTTPCookiePropertyKey.secure: "TRUE",
+                            HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24 * 7)
+                        ]
+                    ].compactMap { HTTPCookie(properties: $0)}
+                    await webVC?.setCookies(cookies)
+                }
+                
+            case .reload:
+                return .run { [webVC = state.webViewController] _ in
+                    await webVC?.webView.reload()
+                }
+                
+            case .goBack:
+                return .run { [webVC = state.webViewController] _ in
+                    guard await webVC?.webView.canGoBack ?? false
+                    else { return await dismiss() }
+                    await webVC?.webView.goBack()
+                    return 
+                    }
+               
+            }
+        }
+    }
+    
+}

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
@@ -1,89 +1,48 @@
 //
-//  PTWebView.swift
+//  StatisticsView.swift
 //  PhysicalTrack
 //
-//  Created by 장석우 on 10/30/24.
+//  Created by 장석우 on 10/18/24.
 //
 
 import SwiftUI
-import Foundation
-import WebKit
+import ComposableArchitecture
 
-struct SMWebView: UIViewRepresentable {
+struct PTWebView: View {
+    let store : StoreOf<PTWebFeature>
+    @Environment(\.presentationMode) var presentationMode
+    private var isOnNavigationStack: Bool { presentationMode.wrappedValue.isPresented }
     
-    var url: String
-    let webView = WKWebView()
-    
-    func makeUIView(context: Context) -> WKWebView {
-        guard let url = URL(string: url) else {
-            print("유효하지 않은 URL")
-            return webView
-        }
-        
-        
-        webView.backgroundColor = .black
-        webView.scrollView.backgroundColor = .black
-        webView.isOpaque = false
-        
-        let cookies = [
-            [
-                HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
-                HTTPCookiePropertyKey.name: "access_token",
-                HTTPCookiePropertyKey.path: "/",
-                HTTPCookiePropertyKey.value: "stub_access_token",
-                HTTPCookiePropertyKey.secure: "TRUE",
-                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24)
-            ],
-            [
-                HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
-                HTTPCookiePropertyKey.name: "user_id",
-                HTTPCookiePropertyKey.path: "/",
-                HTTPCookiePropertyKey.value: "stub_user_id",
-                HTTPCookiePropertyKey.secure: "TRUE",
-                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24 * 7)
-            ]
-        ]
-        
-        // 모든 쿠키 설정 후 페이지를 로드하기 위해 DispatchGroup 사용
-        let dispatchGroup = DispatchGroup()
-        
-        for properties in cookies {
-            if let cookie = HTTPCookie(properties: properties) {
-                dispatchGroup.enter()
-                webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
-                    dispatchGroup.leave()
+    var backButton : some View {
+            Button{
+                store.send(.goBack)
+            } label: {
+                HStack {
+                    Image(systemName: "chevron.left")
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundStyle(.ptWhite)
                 }
             }
         }
-        
-        dispatchGroup.notify(queue: .main) {
-            webView.load(URLRequest(url: url))
-        }
-        
-        
-        return webView
-    }
     
-    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<SMWebView>) {
-        guard let url = URL(string: url) else { return }
-        webView.load(URLRequest(url: url))
+    
+    var body: some View {
+        VStack {
+            store.webViewController
+        }
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: isOnNavigationStack ? backButton : nil)
+        .onAppear {
+            store.send(.onAppear)
+        }
+            
     }
 }
 
-extension SMWebView {
-    func printCookie() {
-        webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            cookies.forEach { cookie in
-                print("""
-                        -------------------
-                        Cookie name: \(cookie.name)
-                        Value: \(cookie.value)
-                        Domain: \(cookie.domain)
-                        Path: \(cookie.path)
-                        Expires: \(String(describing: cookie.expiresDate))
-                        Is Secure: \(cookie.isSecure)
-                        """)
-            }
+#Preview {
+    PTWebView(
+        store: .init(initialState: PTWebFeature.State(url: "https://github.com/")) {
+            PTWebFeature()
         }
-    }
+    )
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
@@ -11,11 +11,11 @@ import ComposableArchitecture
 struct PTWebView: View {
     let store : StoreOf<PTWebFeature>
     @Environment(\.presentationMode) var presentationMode
-    private var isOnNavigationStack: Bool { presentationMode.wrappedValue.isPresented }
+    private var isPresented: Bool { presentationMode.wrappedValue.isPresented }
     
     var backButton : some View {
             Button{
-                store.send(.goBack)
+                store.send(.backButtonTapped)
             } label: {
                 HStack {
                     Image(systemName: "chevron.left")
@@ -31,7 +31,7 @@ struct PTWebView: View {
             store.webViewController
         }
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: isOnNavigationStack ? backButton : nil)
+        .navigationBarItems(leading: isPresented || store.canGoBack ? backButton : nil)
         .onAppear {
             store.send(.onAppear)
         }

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
@@ -1,0 +1,34 @@
+//
+//  PTWebView.swift
+//  PhysicalTrack
+//
+//  Created by 장석우 on 10/30/24.
+//
+
+import SwiftUI
+import WebKit
+
+struct SMWebView: UIViewRepresentable {
+    var url: String
+    
+    func makeUIView(context: Context) -> WKWebView {
+        guard let url = URL(string: url) else {
+            print("유효하지 않은 URL")
+            return WKWebView()
+        }
+        
+        let webView = WKWebView()
+        webView.backgroundColor = .black
+        webView.scrollView.backgroundColor = .black
+        webView.isOpaque = false
+        webView.load(URLRequest(url: url))
+        
+        return webView
+    }
+    
+    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<SMWebView>) {
+        guard let url = URL(string: url) else { return }
+        
+        webView.load(URLRequest(url: url))
+    }
+}

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebView.swift
@@ -6,29 +6,84 @@
 //
 
 import SwiftUI
+import Foundation
 import WebKit
 
 struct SMWebView: UIViewRepresentable {
+    
     var url: String
+    let webView = WKWebView()
     
     func makeUIView(context: Context) -> WKWebView {
         guard let url = URL(string: url) else {
             print("유효하지 않은 URL")
-            return WKWebView()
+            return webView
         }
         
-        let webView = WKWebView()
+        
         webView.backgroundColor = .black
         webView.scrollView.backgroundColor = .black
         webView.isOpaque = false
-        webView.load(URLRequest(url: url))
+        
+        let cookies = [
+            [
+                HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
+                HTTPCookiePropertyKey.name: "access_token",
+                HTTPCookiePropertyKey.path: "/",
+                HTTPCookiePropertyKey.value: "stub_access_token",
+                HTTPCookiePropertyKey.secure: "TRUE",
+                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24)
+            ],
+            [
+                HTTPCookiePropertyKey.domain: "physical-t-p3n2.vercel.app",
+                HTTPCookiePropertyKey.name: "user_id",
+                HTTPCookiePropertyKey.path: "/",
+                HTTPCookiePropertyKey.value: "stub_user_id",
+                HTTPCookiePropertyKey.secure: "TRUE",
+                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24 * 7)
+            ]
+        ]
+        
+        // 모든 쿠키 설정 후 페이지를 로드하기 위해 DispatchGroup 사용
+        let dispatchGroup = DispatchGroup()
+        
+        for properties in cookies {
+            if let cookie = HTTPCookie(properties: properties) {
+                dispatchGroup.enter()
+                webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
+                    dispatchGroup.leave()
+                }
+            }
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            webView.load(URLRequest(url: url))
+        }
+        
         
         return webView
     }
     
     func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<SMWebView>) {
         guard let url = URL(string: url) else { return }
-        
         webView.load(URLRequest(url: url))
+    }
+}
+
+extension SMWebView {
+    func printCookie() {
+        webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+            cookies.forEach { cookie in
+                print("""
+                        -------------------
+                        Cookie name: \(cookie.name)
+                        Value: \(cookie.value)
+                        Domain: \(cookie.domain)
+                        Path: \(cookie.path)
+                        Expires: \(String(describing: cookie.expiresDate))
+                        Is Secure: \(cookie.isSecure)
+                        """)
+            }
+        }
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebViewController.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebViewController.swift
@@ -1,5 +1,5 @@
 //
-//  PTWebView.swift
+//  RepresentableWebView.swift
 //  PhysicalTrack
 //
 //  Created by 장석우 on 10/30/24.
@@ -10,7 +10,7 @@ import Foundation
 import WebKit
 import ComposableArchitecture
 
-struct PTWebViewController: UIViewRepresentable, Equatable {
+struct RepresentableWebView: UIViewRepresentable, Equatable {
     
     let webView: WKWebView = WKWebView()
     
@@ -33,10 +33,10 @@ struct PTWebViewController: UIViewRepresentable, Equatable {
         return webView
     }
     
-    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<PTWebViewController>) { }
+    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<RepresentableWebView>) { }
 }
 
-extension PTWebViewController {
+extension RepresentableWebView {
     func printCookie() {
         webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
             cookies.forEach { cookie in

--- a/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebViewController.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Web/PTWebViewController.swift
@@ -1,0 +1,57 @@
+//
+//  PTWebView.swift
+//  PhysicalTrack
+//
+//  Created by 장석우 on 10/30/24.
+//
+
+import SwiftUI
+import Foundation
+import WebKit
+import ComposableArchitecture
+
+struct PTWebViewController: UIViewRepresentable, Equatable {
+    
+    let webView: WKWebView = WKWebView()
+    
+    @MainActor
+    func load(with url: URL) {
+        webView.load(URLRequest(url: url))
+    }
+    
+    @MainActor
+    func setCookies(_ cookies: [HTTPCookie]) async {
+        for cookie in cookies {
+            await webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+        }
+    }
+    
+    func makeUIView(context: Context) -> WKWebView {
+        webView.backgroundColor = .black
+        webView.scrollView.backgroundColor = .black
+        webView.isOpaque = false
+        return webView
+    }
+    
+    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<PTWebViewController>) { }
+}
+
+extension PTWebViewController {
+    func printCookie() {
+        webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+            cookies.forEach { cookie in
+                print("""
+                        -------------------
+                        Cookie name: \(cookie.name)
+                        Value: \(cookie.value)
+                        Domain: \(cookie.domain)
+                        Path: \(cookie.path)
+                        Expires: \(String(describing: cookie.expiresDate))
+                        Is Secure: \(cookie.isSecure)
+                        """)
+            }
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #10

### ✅ 작업한 내용
- WebView 구현
- TCA WebView 리팩
- backButton 로직 고도화

### ❗️PR Point
### 1. Invalid parameter not satisfying: targetNode 오류
**상황:**
- WebView를 TCA로 리팩한 후, WebView 스크롤 제스처 오류가 뜨며 앱 크래시 발생

**원인**
- WKWebView객체가 레이아웃을 잡기전에 load동작이 수행된 것으로 추정
- 기존엔 아래와 같이 State의 init시점에 RepresentableWebView를 초기화 하고 있었음
```swift
// AS IS
struct State {
    var webView = RepresentableWebView()
}
```
**해결**
```swift
// TO BE
struct State {
    var webView: RepresentableWebView?
}

...

case .onAppear:
    state.webView = RepresentableWebView()
```
**참고**
- https://forums.developer.apple.com/forums/thread/61432

### 2. ObservableState가  연산프로퍼티의 변화를 감지 못하는 문제

**상황**
- view에서 canGoBack: Bool 에따라 백버튼을 보여줄 지 말지 결정해야 하는 상황
- State에서 아래와 같이 구현함
```swift
@ObservableState
struct State {
    var webView: RepresentableWebView?
    var canGoBack: Bool { webView.canGoBack }
}
```

**원인**
- ObservableState는 연산프로퍼티에 값이 변경되어도 이를 notify 하지 못함.
- 따라서 뷰에 update가 일어나지 않음.

**해결**
- Effect `.publisher` 를 통해 canGoBack의 변화를 Action으로 방출한 후, 이를 저장프로퍼티 canGoBack에 반영

**참고**
- https://github.com/pointfreeco/swift-composable-architecture/discussions/1987

### 3. canGoBack이 정상적으로 반영되지 않는 이유

**상황**
- 탭에서 웹뷰 들어간후 다른 탭에 갔다가 다시 해당 웹뷰에 들어왔을 때 canGoBack이 정상적으로 작동하지 않음.

**원인**
- SwiftUI의 View의 onAppear는 다른화면을 갔다가 돌아올때마다 호출됨.
- 이때마다 representableWebView를 갱신해주던 것이 문제

**해결**
- representableWebView초기화를 nil일때만 해주어, 오직 한번만 초기화 하도록 변경


### 📸 스크린샷
![webView](https://github.com/user-attachments/assets/aff36ac7-b4cd-4dc9-b735-015d7f51f5c4)

