### PR TITLE
수행한 러닝 기록을 서버에 전송한다. #61

### DIFF
--- a/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
+++ b/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		874ED62C2CF475A20033972E /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874ED62B2CF475A20033972E /* TutorialView.swift */; };
 		8754676D2CC3C57A00144BE3 /* HeaderTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */; };
 		876C5C682D636E70000C36A7 /* CriteriaDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C5C672D636E70000C36A7 /* CriteriaDescription.swift */; };
+		876C5C6A2D64CB12000C36A7 /* WorkoutResultFeatureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C5C692D64CB12000C36A7 /* WorkoutResultFeatureTest.swift */; };
 		87957D1C2D5B760F00F70FDB /* OpenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D1B2D5B760F00F70FDB /* OpenSettings.swift */; };
 		87957D1E2D5B993600F70FDB /* AuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D1D2D5B993600F70FDB /* AuthorizationStatus.swift */; };
 		87957D212D5C5A9C00F70FDB /* PushUpFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D202D5C5A9C00F70FDB /* PushUpFeature.swift */; };
@@ -182,6 +183,7 @@
 		874ED62B2CF475A20033972E /* TutorialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialView.swift; sourceTree = "<group>"; };
 		8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTabFeature.swift; sourceTree = "<group>"; };
 		876C5C672D636E70000C36A7 /* CriteriaDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriteriaDescription.swift; sourceTree = "<group>"; };
+		876C5C692D64CB12000C36A7 /* WorkoutResultFeatureTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutResultFeatureTest.swift; sourceTree = "<group>"; };
 		8789F1102D5538C800C46132 /* PhysicalTrackUnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PhysicalTrackUnitTests.xctestplan; sourceTree = "<group>"; };
 		87957D1B2D5B760F00F70FDB /* OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSettings.swift; sourceTree = "<group>"; };
 		87957D1D2D5B993600F70FDB /* AuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationStatus.swift; sourceTree = "<group>"; };
@@ -730,6 +732,7 @@
 				87D49E472CE6003700B880DE /* PushUpFeatureTest.swift */,
 				87A479D12D575EA400A5BFDC /* UserInfoFeatureTest.swift */,
 				87A479ED2D5B594C00A5BFDC /* RunningFeatureTest.swift */,
+				876C5C692D64CB12000C36A7 /* WorkoutResultFeatureTest.swift */,
 			);
 			path = PhysicalTrackUnitTests;
 			sourceTree = "<group>";
@@ -943,6 +946,7 @@
 				872F5F392CE4733700887565 /* WorkoutFeatureTest.swift in Sources */,
 				87D49E482CE6003700B880DE /* PushUpFeatureTest.swift in Sources */,
 				87FFBD7B2CD660CE001AB389 /* JWTDecoderTests.swift in Sources */,
+				876C5C6A2D64CB12000C36A7 /* WorkoutResultFeatureTest.swift in Sources */,
 				87A479EE2D5B594C00A5BFDC /* RunningFeatureTest.swift in Sources */,
 				87A479D22D575EA400A5BFDC /* UserInfoFeatureTest.swift in Sources */,
 			);
@@ -1110,7 +1114,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -1147,7 +1151,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;

--- a/PhysicalTrack/PhysicalTrack/App/PhysicalTrackApp.swift
+++ b/PhysicalTrack/PhysicalTrack/App/PhysicalTrackApp.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 @main
 struct PhysicalTrackApp: App {
     let store = Store(initialState: RootFeature.State()) {
-        RootFeature()._printChanges()
+        RootFeature()
     }
 
     var body: some Scene {

--- a/PhysicalTrack/PhysicalTrack/Dependency/Local/AudioClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Local/AudioClient.swift
@@ -22,7 +22,7 @@ extension DependencyValues {
 }
 
 extension AudioClient: DependencyKey {
-    static var liveValue: Self = Self(
+    static let liveValue: Self = Self(
         play: {
             guard let url = Bundle.main.url(forResource: "beep", withExtension: "wav")
             else { return }
@@ -33,8 +33,8 @@ extension AudioClient: DependencyKey {
 }
 
 extension AudioClient: TestDependencyKey {
-    static var previewValue: AudioClient = liveValue
-    static var testValue: AudioClient = Self(
+    static let previewValue: AudioClient = liveValue
+    static let testValue: AudioClient = Self(
         play: {}
     )
 }

--- a/PhysicalTrack/PhysicalTrack/Dependency/Local/ProximityClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Local/ProximityClient.swift
@@ -16,7 +16,6 @@ struct ProximityClient {
 }
 
 extension ProximityClient: TestDependencyKey {
-//    static let liveValue = previewValue
     static let previewValue = Self(
         start: {
             var clock = ContinuousClock()

--- a/PhysicalTrack/PhysicalTrack/Dependency/Remote/LocationClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Remote/LocationClient.swift
@@ -68,15 +68,20 @@ extension LocationClient: TestDependencyKey {
         liveUpdates: {
             let (stream, continuation) = AsyncStream.makeStream(of: Location.self)
             Task {
-                continuation.yield(.stub(distance: { _ in 0 }))
-                sleep(2)
-                continuation.yield(.stub(distance: { _ in 1000 }))
-                sleep(1)
-                continuation.yield(.stub(distance: { _ in 1000 }))
-                sleep(1)
-                continuation.yield(.stub(distance: { _ in 999 }))
-                sleep(1)
-                continuation.yield(.stub(distance: { _ in 3 }))
+//                continuation.yield(.stub(distance: { _ in 0 }))
+//                sleep(2)
+//                continuation.yield(.stub(distance: { _ in 1000 }))
+//                sleep(1)
+//                continuation.yield(.stub(distance: { _ in 1000 }))
+//                sleep(1)
+//                continuation.yield(.stub(distance: { _ in 999 }))
+//                sleep(1)
+//                continuation.yield(.stub(distance: { _ in 3 }))
+                
+                for _ in 0...31 {
+                    continuation.yield(.stub(timestamp: Date(), distance: { _ in 100}))
+                    try await Task.sleep(for: .seconds(1))
+                }
                 
             }
             return stream

--- a/PhysicalTrack/PhysicalTrack/Dependency/Remote/LocationClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Remote/LocationClient.swift
@@ -43,7 +43,7 @@ struct LocationClient {
 
 extension LocationClient: DependencyKey {
     
-    static var liveValue: LocationClient = {
+    static let liveValue: LocationClient = {
         return LocationClient(
             authorizationStatus: { CLLocationManager().authorizationStatus.toDomain() },
             requestAuthorization: { CLLocationManager().requestWhenInUseAuthorization() },
@@ -62,7 +62,7 @@ extension LocationClient: DependencyKey {
 }
 
 extension LocationClient: TestDependencyKey {
-    static var previewValue: LocationClient = Self(
+    static let previewValue: LocationClient = Self(
         authorizationStatus: { .authorized },
         requestAuthorization: { },
         liveUpdates: {
@@ -87,7 +87,7 @@ extension LocationClient: TestDependencyKey {
             return stream
         }
     )
-    static var testValue: LocationClient = Self()
+    static let testValue: LocationClient = Self()
 }
 
 extension DependencyValues {

--- a/PhysicalTrack/PhysicalTrack/Dependency/Remote/UserClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Remote/UserClient.swift
@@ -10,7 +10,6 @@ import ComposableArchitecture
 
 @DependencyClient
 struct UserClient: NetworkRequestable {
-    @Shared(.appStorage(key: .accessToken)) private static var accessToken: String = ""
     var fetch: @Sendable () async throws -> UserInfo
     var update: @Sendable (_ body: UserInfo) async throws -> Void
     var withdraw: @Sendable () async throws -> Void
@@ -42,7 +41,7 @@ extension UserClient: DependencyKey {
     static var liveValue: Self {
         Self(
             fetch: {
-                
+                @Shared(.appStorage(key: .accessToken)) var accessToken: String = ""
                 let urlRequest = try URLRequest(
                     path: "/account",
                     method: .get,
@@ -52,7 +51,7 @@ extension UserClient: DependencyKey {
                 return try await request(for: urlRequest, dto: UserInfoResponse.self).toDomain()
             },
             update: { body in
-                
+                @Shared(.appStorage(key: .accessToken)) var accessToken: String = ""
                 let urlRequest = try URLRequest(
                     path: "/account",
                     method: .put,
@@ -63,6 +62,7 @@ extension UserClient: DependencyKey {
                 return try await request(for: urlRequest)
             },
             withdraw: {
+                @Shared(.appStorage(key: .accessToken)) var accessToken: String = ""
                 let urlRequest = try URLRequest(
                     path: "/account",
                     method: .delete,

--- a/PhysicalTrack/PhysicalTrack/Entity/Location.swift
+++ b/PhysicalTrack/PhysicalTrack/Entity/Location.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 import CoreLocation
+import ConcurrencyExtras
 
-struct Location {
+
+struct Location: Sendable {
     private let rawValue: CLLocation
     
     let speed: Double
     let timestamp: Date
-    let distance: ((_ location: Self) -> Double)
+    @UncheckedSendable var distance: ((_ location: Self) -> Double)
     
     init(
         rawValue: CLLocation

--- a/PhysicalTrack/PhysicalTrack/Entity/PushUp/PushUpRecord.swift
+++ b/PhysicalTrack/PhysicalTrack/Entity/PushUp/PushUpRecord.swift
@@ -10,24 +10,44 @@ import Foundation
 struct PushUpRecord: Equatable {
     let duration: Duration
     let targetCount: Int
-    var count: Int = 0
-    var tempo : [Double] = []
+    var count: Int
+    var tempo : [Double]
     
     var pace: Double {
         Double(count) / Double(duration.components.seconds)
     }
     
     init(for grade: Grade) {
-        self.duration = .seconds(120)
-        self.targetCount = PushUpCriteria.table[grade]?.lowerBound ?? 0
+        self.init(
+            duration: .seconds(120),
+            targetCount: PushUpCriteria.table[grade]?.lowerBound ?? 0,
+            count: 0,
+            tempo: []
+        )
     }
     
-    init(duration: Duration, targetCount: Int) {
+    init(
+        duration: Duration,
+        targetCount: Int,
+        count: Int,
+        tempo: [Double]
+    ) {
         self.duration = duration
         self.targetCount = targetCount
-        self.count = 0
+        self.count = count
+        self.tempo = tempo
+    }
+    
+    static func stub(
+        duration: Duration = .seconds(120),
+        targetCount: Int = 72,
+        count: Int = 0,
+        tempo: [Double] = []
+    ) -> PushUpRecord {
+        self.init(duration: duration, targetCount: targetCount, count: count, tempo: tempo)
     }
 }
+
 
 extension PushUpRecord {
     func evaluate() -> Grade {

--- a/PhysicalTrack/PhysicalTrack/Entity/Running/RunningRecord.swift
+++ b/PhysicalTrack/PhysicalTrack/Entity/Running/RunningRecord.swift
@@ -12,7 +12,7 @@ enum RunningPolicy {
     static let unitDistance = 100
 }
 
-struct RunningRecord: Equatable {
+struct RunningRecord: Equatable, Sendable {
     let targetDuration: Duration
     let targetDistance = 3000
     

--- a/PhysicalTrack/PhysicalTrack/Feature/PushUp/PushUpFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/PushUp/PushUpFeature.swift
@@ -98,7 +98,7 @@ struct PushUpFeature {
                         }
                     },
                     .run { send in
-                        for await detected in proximityClient.start() {
+                        for await detected in await proximityClient.start() {
                             if detected { await send(.detected) }
                         }
                     }
@@ -116,13 +116,13 @@ struct PushUpFeature {
                 return .none
                 
             case .pause:
-                proximityClient.stop()
-                return .cancel(id: CancelID.workout)
-                
+                return .merge(
+                    .run { _ in await proximityClient.stop() },
+                    .cancel(id: CancelID.workout)
+                )
             case .finish:
                 state.presentResult = true
-                proximityClient.stop()
-                return .cancel(id: CancelID.workout)
+                return .send(.pause)
                 
             case .detected:
                 hapticClient.impact(.heavy)

--- a/PhysicalTrack/PhysicalTrack/Feature/PushUp/PushUpFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/PushUp/PushUpFeature.swift
@@ -8,6 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
+
 @Reducer
 struct PushUpFeature {
     
@@ -179,3 +180,4 @@ struct PushUpFeature {
 }
 
 
+extension PushUpFeature.Action.Alert: Equatable { }

--- a/PhysicalTrack/PhysicalTrack/Feature/Workout/WorkoutFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Workout/WorkoutFeature.swift
@@ -153,11 +153,14 @@ struct WorkoutFeature {
         }
         .ifLet(\.$pushUp, action: \.pushUp) {
             PushUpFeature()
-                .dependency(\.continuousClock, ImmediateClock())
         }
         .ifLet(\.$running, action: \.running) {
+#if DEBUG
             RunningFeature()
                 .dependency(\.locationClient, .previewValue)
+            #else
+            RunningFeature()
+            #endif
                 
         }
         .ifLet(\.$alert, action: \.alert)

--- a/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/PushUpResultFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/PushUpResultFeature.swift
@@ -24,23 +24,22 @@ struct PushUpResultFeature {
     
     enum Action {
         case onAppear
-        case postPushUpResponse(Result<Void, Error>)
+        case savePushUpRecordResponse(Result<Void, Error>)
     }
     
-    @Dependency(\.workoutClient) var workoutClient
+    @Dependency(\.workoutClient.savePushUpRecord) var savePushUpRecord
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
                 return .run { [record = state.record] send in
-                    let dto: PushUpRecordRequest = record.toData()
-                    let result = await Result { try await workoutClient.postPushUp(dto) }
-                    await send(.postPushUpResponse(result))
+                    let result = await Result { try await savePushUpRecord(record) }
+                    await send(.savePushUpRecordResponse(result))
                 }
-            case .postPushUpResponse(.success):
+            case .savePushUpRecordResponse(.success):
                 return .none
-            case .postPushUpResponse(.failure):
+            case .savePushUpRecordResponse(.failure):
                 return .none
 
             }

--- a/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/RunningResultFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/RunningResultFeature.swift
@@ -24,23 +24,22 @@ struct RunningResultFeature {
     
     enum Action {
         case onAppear
-        case postRunningResponse(Result<Void, Error>)
+        case saveRunningRecordResponse(Result<Void, Error>)
     }
     
-    @Dependency(\.workoutClient) var workoutClient
+    @Dependency(\.workoutClient.saveRunningRecord) var saveRunningRecord
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
                 return .run { [record = state.record] send in
-//                    let dto: PushUpRecordRequest = record.toData()
-//                    let result = await Result { try await workoutClient.postPushUp(dto) }
-//                    await send(.postPushUpResponse(result))
+                    let result = await Result { try await saveRunningRecord(record) }
+                    await send(.saveRunningRecordResponse(result))
                 }
-            case .postRunningResponse(.success):
+            case .saveRunningRecordResponse(.success):
                 return .none
-            case .postRunningResponse(.failure):
+            case .saveRunningRecordResponse(.failure):
                 return .none
 
             }

--- a/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/WorkoutResultFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/WorkoutResultFeature.swift
@@ -56,5 +56,11 @@ struct WorkoutResultFeature {
                 return .none
             }
         }
+        .ifCaseLet(\.pushUp, action: \.pushUp) {
+            PushUpResultFeature()
+        }
+        .ifCaseLet(\.running, action: \.running) {
+            RunningResultFeature()
+        }
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/WorkoutResultView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/WorkoutResult/WorkoutResultView.swift
@@ -21,10 +21,20 @@ struct WorkoutResultView: View {
                     
                     HStack {
                         switch store.state {
-                        case .pushUp(let state):
-                            ResultPushUpView(record: state.record)
-                        case .running(let state):
-                            ResultRunningView(record: state.record)
+                        case .pushUp:
+                            if let store = store.scope(
+                                state: \.pushUp,
+                                action: \.pushUp
+                            ) {
+                                ResultPushUpView(store: store)
+                            }
+                        case .running:
+                            if let store = store.scope(
+                                state: \.running,
+                                action: \.running
+                            ) {
+                                ResultRunningView(store: store)
+                            }
                         }
                     }
                     .padding(.vertical, 20)
@@ -102,92 +112,94 @@ fileprivate struct ResultTitleView : View {
 }
 
 fileprivate struct ResultRunningView: View {
-    private let record: RunningRecord
     
-    init(record: RunningRecord) {
-        self.record = record
-    }
+    let store: StoreOf<RunningResultFeature>
     
     var body: some View {
-        
-        Spacer()
-        VStack {
-            Text("시간")
-                .foregroundStyle(.ptLightGray01)
+        Group {
+            Spacer()
+            VStack {
+                Text("시간")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text(store.record.currentDuration.formatted(.time(pattern: .minuteSecond)))
+                    .bold()
+            }
             
-            Spacer().frame(height: 14)
+            Spacer()
+            VStack {
+                Text("거리")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text("\(Int(store.record.targetDistance / 1000)) km")
+                    .bold()
+            }
+            Spacer()
             
-            Text(record.currentDuration.formatted(.time(pattern: .minuteSecond)))
-                .bold()
+            VStack {
+                Text("속도")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text(String(format: "%0.2f", store.record.speed))
+                    .bold()
+            }
+            Spacer()
         }
-        
-        Spacer()
-        VStack {
-            Text("거리")
-                .foregroundStyle(.ptLightGray01)
-            
-            Spacer().frame(height: 14)
-            
-            Text("\(Int(record.targetDistance / 1000)) km")
-                .bold()
+        .onAppear {
+            store.send(.onAppear)
         }
-        Spacer()
-        
-        VStack {
-            Text("속도")
-                .foregroundStyle(.ptLightGray01)
-            
-            Spacer().frame(height: 14)
-            
-            Text(String(format: "%0.2f", record.speed))
-                .bold()
-        }
-        Spacer()
     }
 }
 
 fileprivate struct ResultPushUpView: View {
-    private let record: PushUpRecord
     
-    init(record: PushUpRecord) {
-        self.record = record
-    }
+    let store: StoreOf<PushUpResultFeature>
     
     var body: some View {
-        
-        Spacer()
-        VStack {
-            Text("시간")
-                .foregroundStyle(.ptLightGray01)
+        Group {
+            Spacer()
+            VStack {
+                Text("시간")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text(String(store.record.duration.components.seconds))
+                    .bold()
+            }
             
-            Spacer().frame(height: 14)
+            Spacer()
+            VStack {
+                Text("횟수")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text(String(store.record.count))
+                    .bold()
+            }
+            Spacer()
             
-            Text(String(record.duration.components.seconds))
-                .bold()
+            VStack {
+                Text("페이스")
+                    .foregroundStyle(.ptLightGray01)
+                
+                Spacer().frame(height: 14)
+                
+                Text(String(format: "%0.2f", store.record.pace))
+                    .bold()
+            }
+            Spacer()
         }
-        
-        Spacer()
-        VStack {
-            Text("횟수")
-                .foregroundStyle(.ptLightGray01)
-            
-            Spacer().frame(height: 14)
-            
-            Text(String(record.count))
-                .bold()
+        .onAppear {
+            store.send(.onAppear)
         }
-        Spacer()
-        
-        VStack {
-            Text("페이스")
-                .foregroundStyle(.ptLightGray01)
-            
-            Spacer().frame(height: 14)
-            
-            Text(String(format: "%0.2f", record.pace))
-                .bold()
-        }
-        Spacer()
     }
 }
 

--- a/PhysicalTrack/PhysicalTrack/Network/DTO/WorkoutDTO.swift
+++ b/PhysicalTrack/PhysicalTrack/Network/DTO/WorkoutDTO.swift
@@ -18,5 +18,18 @@ extension PushUpRecord {
     }
 }
 
+struct RunningRecordRequest: Encodable {
+    let duration: Double
+    let tempo: [Double]
+}
+
+extension RunningRecord {
+    func toData() -> RunningRecordRequest {
+        return RunningRecordRequest(
+            duration: Double(self.currentDuration.components.seconds),
+            tempo: self.timeIntervals
+        )
+    }
+}
 
 

--- a/PhysicalTrack/PhysicalTrack/Shared/Web/RepresentableWebView.swift
+++ b/PhysicalTrack/PhysicalTrack/Shared/Web/RepresentableWebView.swift
@@ -55,3 +55,20 @@ extension RepresentableWebView {
     
     
 }
+
+
+extension WKWebView {
+    func canGoBackStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let observation = observe(\.canGoBack, options: [.initial, .new]) { webView, change in
+                if let newValue = change.newValue {
+                    continuation.yield(newValue)
+                }
+            }
+            
+            continuation.onTermination = { _ in
+                observation.invalidate()
+            }
+        }
+    }
+}

--- a/PhysicalTrack/PhysicalTrackUnitTests/PushUpFeatureTest.swift
+++ b/PhysicalTrack/PhysicalTrackUnitTests/PushUpFeatureTest.swift
@@ -6,113 +6,100 @@
 //
 
 import Testing
-import ComposableArchitecture
-@testable import PhysicalTrack
 
-//@MainActor
-//struct PushUpFeatureTest {
-//    
-//    @Test
-//    func 푸시업기록_엔티티의_기간은_120초이다() async {
-//        #expect(PushUpRecord(for: .elite).duration == .seconds(120))
-//    }
-//    
-//    
-//    @Test
-//    func test_when_onAppear_then_ready_3초후_시작() async {
-//        let clock = ImmediateClock()
-//        let store = TestStore(
-//            initialState: PushUpFeature.State(
-//                PushUpRecord.init(
-//                    duration: .seconds(120),
-//                    targetCount: 72,
-//                    count: 0,
-//                    tempo: []
-//                )
-//            )) {
-//                PushUpFeature()
-//            } withDependencies: {
-//                $0.continuousClock = clock
-//            }
-//        
-//        store.exhaustivity = .off
-//        
-//        await store.send(.onAppear)
-//        await store.receive(\.ready)
-//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 2 }
-//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 1 }
-//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 0 }
-//        await store.receive(\.readyTimerTick)
-//        await store.receive(\.start)
-//        await store.finish()
-//        
-//    }
-//    
-//    @Test
-//    func test_종료버튼을누르면_타이머가_중단된다() async {
-//        let clock = TestClock()
-//        let store = TestStore(initialState: PushUpFeature.State(
-//            PushUpRecord.init(
-//                duration: .seconds(120),
-//                targetCount: 72,
-//                count: 0,
-//                tempo: []
-//            )
-//        )) {
-//            PushUpFeature()
-//        } withDependencies: {
-//            $0.proximityClient = .testValue
-//            $0.continuousClock = clock
-//        }
-//        
-//        store.exhaustivity = .off
-//        
-//        await store.send(.start)
-//        await store.send(.quitButtonTapped)
-//        await store.receive(\.pause)
-//        
-//        await clock.advance(by: .seconds(7))
-//        
-//        await store.finish()
-//    }
-//    
-//    //
-//    //
-//    //    @Test
-//    //    func test_종료버튼을_누르면_ProximityClient를_cancel한다() async {
-//    //        let clock = TestClock()
-//    //        let proximityStream = AsyncStream.makeStream(of: Bool.self)
-//    //        let stubProximityStream = ProximityClient(
-//    //            start: {@Sendable in proximityStream.stream },
-//    //            stop: { @Sendable in proximityStream.continuation.finish() }
-//    //        )
-//    //        let store = TestStore(initialState: PushUpFeature.State(
-//    //            .stub(duration: .seconds(120), targetCount: 10, count: 0, tempo: [])
-//    //        )) {
-//    //            PushUpFeature()
-//    //        } withDependencies: {
-//    //            $0.proximityClient = stubProximityStream
-//    //            $0.continuousClock = clock
-//    //        }
-//    //
-//    //        store.exhaustivity = .off
-//    //
-//    //        await store.send(.start) {
-//    //            $0.record.count = 0
-//    //        }
-//    //
-//    //        await store.send(.quitButtonTapped)
-//    //        await store.receive(\.pause)
-//    //
-//    //        let before = store.state.record.count
-//    //        // 무효화 되어야 할 운동 ---
-//    //        proximityStream.continuation.yield(true) //영
-//    //        proximityStream.continuation.yield(false) //차
-//    //        // ---
-//    //        let after = store.state.record.count
-//    //
-//    //        #expect(before == after)
-//    //        await store.finish()
-//    //    }
-//    //}
-//}
+@testable import PhysicalTrack
+import ComposableArchitecture
+
+@MainActor
+struct PushUpFeatureTest {
+    
+    @Test
+    func 푸시업기록_엔티티의_기간은_120초이다() async {
+        #expect(PushUpRecord(for: .elite).duration == .seconds(120))
+    }
+    
+    @Test
+    func 푸시업뷰_진입시_준비타이머_3초후_운동이_시작된다() async {
+        let clock = ImmediateClock()
+        let store = TestStore(
+            initialState: PushUpFeature.State(
+                PushUpRecord.stub()
+            )) {
+                PushUpFeature()
+            } withDependencies: {
+                $0.continuousClock = clock
+            }
+        
+        store.exhaustivity = .off
+        
+        await store.send(.onAppear)
+        await store.receive(\.ready)
+        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 2 }
+        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 1 }
+        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 0 }
+        await store.receive(\.readyTimerTick)
+        await store.receive(\.start)
+        await store.finish()
+        
+    }
+    
+    @Test
+    func 정지버튼을_누르면_실제시간이_흘러도_운동시간은_증가하지_않는다() async {
+        let clock = TestClock()
+        let store = TestStore(initialState: PushUpFeature.State(
+            PushUpRecord.stub()
+        )) {
+            PushUpFeature()
+        } withDependencies: {
+            $0.proximityClient = .testValue
+            $0.continuousClock = clock
+        }
+        
+        store.exhaustivity = .off
+        
+        await store.send(.start)
+        await store.send(.quitButtonTapped)
+        await store.receive(\.pause)
+        
+        let before = store.state.workoutLeftSeconds
+        await clock.advance(by: .seconds(7))
+        let after = store.state.workoutLeftSeconds
+        
+        #expect(before == after)
+    }
+    
+    @Test
+    func 정지버튼을_누르면_근접센서에_값이_들어와도_운동횟수는_증가하지_않는다() async {
+        let clock = TestClock()
+        let (stream, continuation) = AsyncStream.makeStream(of: Bool.self)
+        
+        let store = TestStore(
+            initialState:
+                PushUpFeature.State(.stub())
+        ) {
+            PushUpFeature()
+        } withDependencies: {
+            $0.proximityClient.start = { @Sendable in stream }
+            $0.proximityClient.stop = { @Sendable in continuation.finish() }
+            $0.continuousClock = clock
+        }
+        
+        store.exhaustivity = .off
+        
+        await store.send(.start) {
+            $0.record.count = 0
+        }
+        
+        await store.send(.quitButtonTapped)
+        await store.receive(\.pause)
+        
+        let before = store.state.record.count
+        // 무효화 되어야 할 운동 ---
+        continuation.yield(true) //영
+        continuation.yield(false) //차
+        // ---
+        let after = store.state.record.count
+        
+        #expect(before == after)
+    }
+}

--- a/PhysicalTrack/PhysicalTrackUnitTests/PushUpFeatureTest.swift
+++ b/PhysicalTrack/PhysicalTrackUnitTests/PushUpFeatureTest.swift
@@ -7,99 +7,112 @@
 
 import Testing
 import ComposableArchitecture
-
 @testable import PhysicalTrack
-@MainActor
-struct PushUpFeatureTest {
-    
-    @Test
-    func test_timer가_2분으로_설정되었는가() async {
-        assert(PushUpRecord(for: .elite).duration == .seconds(120))
-    }
-    
-    @Test
-    func test_when_onAppear_then_ready_3초후_시작() async {
-        let clock = ImmediateClock()
-        
-        let store = TestStore(initialState: PushUpFeature.State(
-            .init(duration: .seconds(120), targetCount: 72)
-        )) {
-            PushUpFeature()
-        } withDependencies: {
-            $0.continuousClock = clock
-        }
-        
-        store.exhaustivity = .off
-        
-        await store.send(.onAppear)
-        await store.receive(\.ready)
-        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 2 }
-        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 1 }
-        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 0 }
-        await store.receive(\.readyTimerTick)
-        await store.receive(\.start)
-        await store.finish()
-    }
-    
-    @Test
-    func test_종료버튼을누르면_타이머가_중단된다() async {
-        let clock = TestClock()
-        let store = TestStore(initialState: PushUpFeature.State(
-            PushUpRecord(duration: .seconds(10), targetCount: 10)
-        )) {
-            PushUpFeature()
-        } withDependencies: {
-            $0.proximityClient = .testValue
-            $0.continuousClock = clock
-        }
-        
-        store.exhaustivity = .off
-        
-        await store.send(.start)
-        await store.send(.quitButtonTapped)
-        await store.receive(\.pause)
-        
-        await clock.advance(by: .seconds(7))
-        
-        await store.finish()
-        
-    }
-    
-    
-    @Test
-    func test_종료버튼을_누르면_ProximityClient를_cancel한다() async {
-        let clock = TestClock()
-        let proximityStream = AsyncStream.makeStream(of: Bool.self)
-        let stubProximityStream = ProximityClient(
-            start: {@Sendable in proximityStream.stream },
-            stop: { @Sendable in proximityStream.continuation.finish() }
-        )
-        let store = TestStore(initialState: PushUpFeature.State(
-            PushUpRecord(duration: .seconds(10), targetCount: 10))
-        ) {
-            PushUpFeature()
-        } withDependencies: {
-            $0.proximityClient = stubProximityStream
-            $0.continuousClock = clock
-        }
-        
-        store.exhaustivity = .off
-        
-        await store.send(.start) {
-            $0.record.count = 0
-        }
-        
-        await store.send(.quitButtonTapped)
-        await store.receive(\.pause)
-        
-        let before = store.state.record.count
-        // 무효화 되어야 할 운동 ---
-        proximityStream.continuation.yield(true) //영
-        proximityStream.continuation.yield(false) //차
-        // ---
-        let after = store.state.record.count
-        
-        #expect(before == after)
-        await store.finish()
-    }
-}
+
+//@MainActor
+//struct PushUpFeatureTest {
+//    
+//    @Test
+//    func 푸시업기록_엔티티의_기간은_120초이다() async {
+//        #expect(PushUpRecord(for: .elite).duration == .seconds(120))
+//    }
+//    
+//    
+//    @Test
+//    func test_when_onAppear_then_ready_3초후_시작() async {
+//        let clock = ImmediateClock()
+//        let store = TestStore(
+//            initialState: PushUpFeature.State(
+//                PushUpRecord.init(
+//                    duration: .seconds(120),
+//                    targetCount: 72,
+//                    count: 0,
+//                    tempo: []
+//                )
+//            )) {
+//                PushUpFeature()
+//            } withDependencies: {
+//                $0.continuousClock = clock
+//            }
+//        
+//        store.exhaustivity = .off
+//        
+//        await store.send(.onAppear)
+//        await store.receive(\.ready)
+//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 2 }
+//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 1 }
+//        await store.receive(\.readyTimerTick) { $0.readyLeftSeconds = 0 }
+//        await store.receive(\.readyTimerTick)
+//        await store.receive(\.start)
+//        await store.finish()
+//        
+//    }
+//    
+//    @Test
+//    func test_종료버튼을누르면_타이머가_중단된다() async {
+//        let clock = TestClock()
+//        let store = TestStore(initialState: PushUpFeature.State(
+//            PushUpRecord.init(
+//                duration: .seconds(120),
+//                targetCount: 72,
+//                count: 0,
+//                tempo: []
+//            )
+//        )) {
+//            PushUpFeature()
+//        } withDependencies: {
+//            $0.proximityClient = .testValue
+//            $0.continuousClock = clock
+//        }
+//        
+//        store.exhaustivity = .off
+//        
+//        await store.send(.start)
+//        await store.send(.quitButtonTapped)
+//        await store.receive(\.pause)
+//        
+//        await clock.advance(by: .seconds(7))
+//        
+//        await store.finish()
+//    }
+//    
+//    //
+//    //
+//    //    @Test
+//    //    func test_종료버튼을_누르면_ProximityClient를_cancel한다() async {
+//    //        let clock = TestClock()
+//    //        let proximityStream = AsyncStream.makeStream(of: Bool.self)
+//    //        let stubProximityStream = ProximityClient(
+//    //            start: {@Sendable in proximityStream.stream },
+//    //            stop: { @Sendable in proximityStream.continuation.finish() }
+//    //        )
+//    //        let store = TestStore(initialState: PushUpFeature.State(
+//    //            .stub(duration: .seconds(120), targetCount: 10, count: 0, tempo: [])
+//    //        )) {
+//    //            PushUpFeature()
+//    //        } withDependencies: {
+//    //            $0.proximityClient = stubProximityStream
+//    //            $0.continuousClock = clock
+//    //        }
+//    //
+//    //        store.exhaustivity = .off
+//    //
+//    //        await store.send(.start) {
+//    //            $0.record.count = 0
+//    //        }
+//    //
+//    //        await store.send(.quitButtonTapped)
+//    //        await store.receive(\.pause)
+//    //
+//    //        let before = store.state.record.count
+//    //        // 무효화 되어야 할 운동 ---
+//    //        proximityStream.continuation.yield(true) //영
+//    //        proximityStream.continuation.yield(false) //차
+//    //        // ---
+//    //        let after = store.state.record.count
+//    //
+//    //        #expect(before == after)
+//    //        await store.finish()
+//    //    }
+//    //}
+//}

--- a/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
+++ b/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
@@ -1,56 +1,65 @@
-////
-////  WorkoutResultFeatureTest.swift
-////  PhysicalTrackUnitTests
-////
-////  Created by 장석우 on 2/18/25.
-////
 //
-//import Testing
-//@testable import PhysicalTrack
-//import ComposableArchitecture
+//  WorkoutResultFeatureTest.swift
+//  PhysicalTrackUnitTests
 //
-//@MainActor
-//struct WorkoutResultFeatureTest {
-//    
-//    @Suite("RunningResult")
-//    @MainActor
-//    struct RunningResult { }
-//    
-//    @Suite("PushUpResult")
-//    @MainActor
-//    struct PushUpResult { }
-//}
+//  Created by 장석우 on 2/18/25.
 //
-//extension WorkoutResultFeatureTest {
-//    
-//}
-//
-//extension WorkoutResultFeatureTest.PushUpResult {
-//    
-//    @Test
-//    func 푸시업결과뷰_진입시_푸시업기록을_서버로_전송한다() async {
-//        
-//        let isCalled = LockIsolated(false)
-//        
-//        let store = TestStore(initialState: PushUpResultFeature.State(record: PushUpRecord(for: .elite))) {
-//            PushUpResultFeature()
-//        } withDependencies: {
-//            $0.workoutClient.savePushUpRecord = { _ in isCalled.setValue(true) }
-//        }
-//        
-//        store.exhaustivity = .off
-//        
-//        await store.send(.onAppear)
-//        
-//        #expect(isCalled.value)
-//    }
-//}
-//
-//extension WorkoutResultFeatureTest.RunningResult {
-////    
-////    @Test
-////    func 운동결과뷰_진입시_러닝피쳐_onAppear가_호출된다() async {
-///
 
-////    }
-//}
+import Testing
+@testable import PhysicalTrack
+import ComposableArchitecture
+
+@MainActor
+struct WorkoutResultFeatureTest {
+    
+    @Suite("RunningResult")
+    @MainActor
+    struct RunningResult { }
+    
+    @Suite("PushUpResult")
+    @MainActor
+    struct PushUpResult { }
+}
+
+
+extension WorkoutResultFeatureTest.PushUpResult {
+    
+    @Test
+    func 푸시업결과뷰_진입시_푸시업기록을_서버로_전송한다() async {
+        
+        let isCalled = LockIsolated(false)
+        
+        let store = TestStore(initialState: PushUpResultFeature.State(record: PushUpRecord(for: .elite))) {
+            PushUpResultFeature()
+        } withDependencies: {
+            $0.workoutClient.savePushUpRecord = { _ in isCalled.setValue(true) }
+        }
+        
+        store.exhaustivity = .off
+        
+        await store.send(.onAppear)
+        
+        #expect(isCalled.value)
+    }
+}
+
+extension WorkoutResultFeatureTest.RunningResult {
+    
+    @Test
+    func 러닝결과뷰_진입시_러닝기록을_서버로_전송한다() async {
+        
+        let isCalled = LockIsolated(false)
+        
+        let store = TestStore(initialState: RunningResultFeature.State(record: RunningRecord(for: .elite))) {
+            RunningResultFeature()
+        } withDependencies: {
+            $0.workoutClient.saveRunningRecord = { _ in isCalled.setValue(true) }
+        }
+        
+        store.exhaustivity = .off
+        
+        await store.send(.onAppear)
+        
+        #expect(isCalled.value)
+    }
+}

--- a/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
+++ b/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
@@ -1,8 +1,56 @@
+////
+////  WorkoutResultFeatureTest.swift
+////  PhysicalTrackUnitTests
+////
+////  Created by 장석우 on 2/18/25.
+////
 //
-//  WorkoutResultFeatureTest.swift
-//  PhysicalTrackUnitTests
+//import Testing
+//@testable import PhysicalTrack
+//import ComposableArchitecture
 //
-//  Created by 장석우 on 2/18/25.
+//@MainActor
+//struct WorkoutResultFeatureTest {
+//    
+//    @Suite("RunningResult")
+//    @MainActor
+//    struct RunningResult { }
+//    
+//    @Suite("PushUpResult")
+//    @MainActor
+//    struct PushUpResult { }
+//}
 //
+//extension WorkoutResultFeatureTest {
+//    
+//}
+//
+//extension WorkoutResultFeatureTest.PushUpResult {
+//    
+//    @Test
+//    func 푸시업결과뷰_진입시_푸시업기록을_서버로_전송한다() async {
+//        
+//        let isCalled = LockIsolated(false)
+//        
+//        let store = TestStore(initialState: PushUpResultFeature.State(record: PushUpRecord(for: .elite))) {
+//            PushUpResultFeature()
+//        } withDependencies: {
+//            $0.workoutClient.savePushUpRecord = { _ in isCalled.setValue(true) }
+//        }
+//        
+//        store.exhaustivity = .off
+//        
+//        await store.send(.onAppear)
+//        
+//        #expect(isCalled.value)
+//    }
+//}
+//
+//extension WorkoutResultFeatureTest.RunningResult {
+////    
+////    @Test
+////    func 운동결과뷰_진입시_러닝피쳐_onAppear가_호출된다() async {
+///
 
-import Foundation
+////    }
+//}

--- a/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
+++ b/PhysicalTrack/PhysicalTrackUnitTests/WorkoutResultFeatureTest.swift
@@ -1,0 +1,8 @@
+//
+//  WorkoutResultFeatureTest.swift
+//  PhysicalTrackUnitTests
+//
+//  Created by 장석우 on 2/18/25.
+//
+
+import Foundation


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #61

### ✅ 작업한 내용
- 러닝기록 api 연동
- tca swift syntazx - macro 빌드 문제로 인해 swift 5 -> 6 업그레이드
- swift 6의 동시성 문제 해결

