### PR TITLE
Feat/#63 - 랭킹 탭에서 달리기 순위를 보여준다.

### DIFF
--- a/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
+++ b/PhysicalTrack/PhysicalTrack.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		8754676D2CC3C57A00144BE3 /* HeaderTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */; };
 		876C5C682D636E70000C36A7 /* CriteriaDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C5C672D636E70000C36A7 /* CriteriaDescription.swift */; };
 		876C5C6A2D64CB12000C36A7 /* WorkoutResultFeatureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C5C692D64CB12000C36A7 /* WorkoutResultFeatureTest.swift */; };
+		876C5C702D68D9B3000C36A7 /* RankingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C5C6F2D68D9B3000C36A7 /* RankingCell.swift */; };
 		87957D1C2D5B760F00F70FDB /* OpenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D1B2D5B760F00F70FDB /* OpenSettings.swift */; };
 		87957D1E2D5B993600F70FDB /* AuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D1D2D5B993600F70FDB /* AuthorizationStatus.swift */; };
 		87957D212D5C5A9C00F70FDB /* PushUpFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87957D202D5C5A9C00F70FDB /* PushUpFeature.swift */; };
@@ -184,6 +185,7 @@
 		8754676C2CC3C57A00144BE3 /* HeaderTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTabFeature.swift; sourceTree = "<group>"; };
 		876C5C672D636E70000C36A7 /* CriteriaDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriteriaDescription.swift; sourceTree = "<group>"; };
 		876C5C692D64CB12000C36A7 /* WorkoutResultFeatureTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutResultFeatureTest.swift; sourceTree = "<group>"; };
+		876C5C6F2D68D9B3000C36A7 /* RankingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingCell.swift; sourceTree = "<group>"; };
 		8789F1102D5538C800C46132 /* PhysicalTrackUnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PhysicalTrackUnitTests.xctestplan; sourceTree = "<group>"; };
 		87957D1B2D5B760F00F70FDB /* OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSettings.swift; sourceTree = "<group>"; };
 		87957D1D2D5B993600F70FDB /* AuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationStatus.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 		8717B5F12CC1FB3D00542061 /* Ranking */ = {
 			isa = PBXGroup;
 			children = (
+				876C5C6E2D68D993000C36A7 /* Component */,
 				8735D7542CC371DA00C7824C /* Ranking */,
 				8735D7552CC371E100C7824C /* RankingDetail */,
 			);
@@ -610,6 +613,14 @@
 				8735D75E2CC39E7900C7824C /* DTO */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		876C5C6E2D68D993000C36A7 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				876C5C6F2D68D9B3000C36A7 /* RankingCell.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		87957D1F2D5C565200F70FDB /* PushUp */ = {
@@ -887,6 +898,7 @@
 				874ED6222CF46B110033972E /* GIFView.swift in Sources */,
 				87C59EFD2D40EF83009B96FA /* AnyPTButton+.swift in Sources */,
 				871059E92CC3B1FD00C4362D /* RankingDetailListFeature.swift in Sources */,
+				876C5C702D68D9B3000C36A7 /* RankingCell.swift in Sources */,
 				87B492CE2CF5C4D800628A6E /* RankingDetailListView.swift in Sources */,
 				8754676D2CC3C57A00144BE3 /* HeaderTabFeature.swift in Sources */,
 				87C01C7F2D60C46A000871B6 /* RunningCriteria.swift in Sources */,

--- a/PhysicalTrack/PhysicalTrack/Dependency/Remote/RankingClient.swift
+++ b/PhysicalTrack/PhysicalTrack/Dependency/Remote/RankingClient.swift
@@ -21,6 +21,7 @@ enum RankingError: Error {
 struct RankingClient: NetworkRequestable {
     var fetchConsistency: @Sendable () async throws -> [ConsistencyRankingResponse]
     var fetchPushUp: @Sendable () async throws -> [PushUpRankingResponse]
+    var fetchRunning: @Sendable () async throws -> [RunningRankingResponse]
 }
 
 // MARK: - Live API implementation
@@ -50,6 +51,17 @@ extension RankingClient: DependencyKey {
             )
             
             return try await request(for: urlRequest, dto: [PushUpRankingResponse].self)
+        },
+        fetchRunning: {
+            @Shared(.appStorage(key: .accessToken)) var accessToken = ""
+            
+            let urlRequest: URLRequest = try .init(
+                path: "/ranking/running",
+                method: .get,
+                headers: ["Authorization": accessToken]
+            )
+            
+            return try await request(for: urlRequest, dto: [RunningRankingResponse].self)
         }
         
     )
@@ -71,6 +83,9 @@ extension RankingClient: TestDependencyKey {
         },
         fetchPushUp: {
             [.stub1]
+        },
+        fetchRunning: {
+            []
         }
     )
     

--- a/PhysicalTrack/PhysicalTrack/Entity/RankingRepresentable.swift
+++ b/PhysicalTrack/PhysicalTrack/Entity/RankingRepresentable.swift
@@ -12,4 +12,5 @@ protocol RankingRepresentable: Hashable {
     var name: String { get }
     var rank: Int { get }
     var value: Int { get }
+    func description() -> String
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Component/RankingCell.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Component/RankingCell.swift
@@ -1,0 +1,41 @@
+//
+//  RankingCell.swift
+//  PhysicalTrack
+//
+//  Created by 장석우 on 2/22/25.
+//
+
+import SwiftUI
+
+struct RankingCell: View {
+    
+    let rank: Int
+    let name: String
+    let description: String
+    
+    var body: some View {
+        HStack {
+            Text(String(rank))
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.ptPoint)
+            
+            Text(name)
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.ptWhite)
+                .padding(.leading, 12)
+            
+            Spacer()
+            
+            Text(description)
+                .foregroundStyle(.ptLightGray01)
+                .font(.subheadline)
+        }
+        .padding(.vertical, 12)
+    }
+}
+
+#Preview {
+    RankingCell(rank: 1, name: "장석우", description: "1 회")
+}

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingType.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingType.swift
@@ -11,11 +11,13 @@ enum RankingType: Int, HeaderItemType {
     
     case consistency
     case pushUp
+    case running
     
     var title: String {
         switch self {
         case .consistency: "꾸준함"
         case .pushUp: "팔굽혀펴기"
+        case .running: "3km 달리기"
         }
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
@@ -19,27 +19,26 @@ struct RankingView: View {
                     emptyView
                 } else {
                     ScrollView {
-                        RankingTop3View(store: store,
-                                        type: .consistency,
-                                        rankings: store.consistencyTop3)
-                        
-                        Spacer().frame(height: 14)
-                        
-                        RankingTop3View(store: store,
-                                        type: .pushUp,
-                                        rankings: store.pushUpTop3)
-                        
-                        Spacer().frame(height: 14)
-                        
-                        RankingTop3View(store: store,
-                                        type: .running,
-                                        rankings: store.runningTop3)
-                        
-                        Spacer().frame(height: 24)
+                        VStack(spacing: 14) {
+                            RankingTop3View(store: store,
+                                            type: .consistency,
+                                            rankings: store.consistencyTop3)
+                            
+                            RankingTop3View(store: store,
+                                            type: .pushUp,
+                                            rankings: store.pushUpTop3)
+                            
+                            RankingTop3View(store: store,
+                                            type: .running,
+                                            rankings: store.runningTop3)
+                            
+                            Spacer().frame(height: 10)
+                        }
+                        .background(.black)
                     }
+                    .background(.ptBackground)
                 }
             }
-            .background(.ptBackground)
             .alert($store.scope(state: \.alert, action: \.alert))
             .navigationTitle("이번 주 순위")
             .onAppear {
@@ -99,6 +98,7 @@ fileprivate struct RankingTop3View: View {
                     .font(.title3)
                     .bold()
                     .foregroundStyle(.ptWhite)
+                    .padding(.top, 14)
                     .padding(.bottom, 20)
                 
                 Spacer()
@@ -107,41 +107,39 @@ fileprivate struct RankingTop3View: View {
             if rankings.isEmpty {
                 emptyView
             } else {
-                LazyVStack(spacing: 20) {
+                LazyVStack {
                     ForEach(rankings, id: \.userID) { data in
-                        HStack {
-                            Text(String(data.rank))
-                                .foregroundStyle(.ptLightGray01)
-                                .fontWeight(.semibold)
-                            
-                            Text(data.name)
-                                .foregroundStyle(.ptWhite)
-                            Spacer()
-                            Text(data.description())
-                                .foregroundStyle(.ptLightGray01)
-                        }
+                        RankingCell(
+                            rank: data.rank,
+                            name: data.name,
+                            description: data.description()
+                        )
                     }
                 }
+                
+                Divider()
+                    .padding(.top, 20)
                 
                 Button {
                     store.send(.rankingDetailButtonTapped(type))
                 } label: {
-                    Text("순위 더보기")
-                        .font(.body.bold())
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
-                        .foregroundStyle(.ptWhite)
-                        .background(.ptDarkGray02)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                    HStack(spacing: 10) {
+                        Text("순위 더 보기")
+                            .font(.body)
+                            .bold()
+
+                        Image(systemName: "chevron.right")
+                            
+                    }
+                    .foregroundStyle(.ptLightGray01)
                 }
                 .padding(.top, 20)
             }
         }
-        .padding(18)
-        .background(.ptDarkNavyGray)
-        .clipShape(RoundedRectangle(cornerRadius: 4))
-        .padding(.horizontal, 20)
-        .padding(.top, 20)
+        .padding(.vertical, 20)
+        .padding(.horizontal, 24)
+        .background(.ptBackground)
+        
     }
     
     var emptyView: some View {
@@ -151,6 +149,7 @@ fileprivate struct RankingTop3View: View {
                 .font(.headline)
                 .multilineTextAlignment(.center)
                 .bold()
+                .padding(.top, 12)
             
             Text("지금 운동하면 1위를 차지할 수 있어요!")
                 .font(.subheadline)
@@ -161,11 +160,8 @@ fileprivate struct RankingTop3View: View {
             PTButton("운동 하러가기") {
                 store.send(.workoutButtonTapped)
             }
-            .buttonStyle(
-                .blue,
-                .init(height: 48, font: .body.bold())
-            )
             .frame(width: 160)
+            .padding(.top, 10)
             
             Spacer()
         }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingView.swift
@@ -21,15 +21,21 @@ struct RankingView: View {
                     ScrollView {
                         RankingTop3View(store: store,
                                         type: .consistency,
-                                        description: "일째 운동 중",
                                         rankings: store.consistencyTop3)
                         
                         Spacer().frame(height: 14)
                         
                         RankingTop3View(store: store,
                                         type: .pushUp,
-                                        description: "회",
                                         rankings: store.pushUpTop3)
+                        
+                        Spacer().frame(height: 14)
+                        
+                        RankingTop3View(store: store,
+                                        type: .running,
+                                        rankings: store.runningTop3)
+                        
+                        Spacer().frame(height: 24)
                     }
                 }
             }
@@ -84,7 +90,6 @@ fileprivate struct RankingTop3View: View {
     
     let store: StoreOf<RankingFeature>
     let type: RankingType
-    let description: String
     let rankings: [any RankingRepresentable]
     
     var body: some View {
@@ -112,7 +117,7 @@ fileprivate struct RankingTop3View: View {
                             Text(data.name)
                                 .foregroundStyle(.ptWhite)
                             Spacer()
-                            Text("\(data.value)\(description)")
+                            Text(data.description())
                                 .foregroundStyle(.ptLightGray01)
                         }
                     }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailFeature.swift
@@ -16,12 +16,19 @@ struct RankingDetailFeature {
         var selectedTab: RankingType
         var consistency: RankingDetailListFeature.State? = .init()
         var pushUp: RankingDetailListFeature.State? = .init()
+        var running: RankingDetailListFeature.State? = .init()
         var headerTab: HeaderTabFeature<RankingType>.State? = .init(selectedItem: .consistency)
         
-        init(_ selectedTab: RankingType, _ consistency: [ConsistencyRankingResponse], _ pushUp: [PushUpRankingResponse]) {
+        init(
+            _ selectedTab: RankingType,
+            _ consistency: [ConsistencyRankingResponse],
+            _ pushUp: [PushUpRankingResponse],
+            _ running: [RunningRankingResponse]
+        ) {
             self.selectedTab = selectedTab
             self.consistency = RankingDetailListFeature.State(ranking: consistency)
             self.pushUp = RankingDetailListFeature.State(ranking: pushUp)
+            self.running = RankingDetailListFeature.State(ranking: running)
             self.headerTab = HeaderTabFeature<RankingType>.State(selectedItem: selectedTab)
         }
     }
@@ -30,6 +37,7 @@ struct RankingDetailFeature {
         case selectTab(RankingType)
         case consistency(RankingDetailListFeature.Action)
         case pushUp(RankingDetailListFeature.Action)
+        case running(RankingDetailListFeature.Action)
         case headerTab(HeaderTabFeature<RankingType>.Action)
         case rankCellTapped(any RankingRepresentable)
     }
@@ -41,8 +49,9 @@ struct RankingDetailFeature {
                 return .send(.headerTab(.selectItem(type)))
             case let .consistency(.rankCellTapped(userID)):
                 return .send(.rankCellTapped(userID))
-                
             case let .pushUp(.rankCellTapped(userID)):
+                return .send(.rankCellTapped(userID))
+            case .running(.rankCellTapped(let userID)):
                 return .send(.rankCellTapped(userID))
             case let .headerTab(.selectItem(type)):
                 state.selectedTab = type
@@ -58,11 +67,11 @@ struct RankingDetailFeature {
         .ifLet(\.pushUp, action: \.pushUp) {
             RankingDetailListFeature()
         }
+        .ifLet(\.running, action: \.running) {
+            RankingDetailListFeature()
+        }
         .ifLet(\.headerTab, action: \.headerTab) {
             HeaderTabFeature<RankingType>()
         }
-        
-        
-        
     }
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListFeature.swift
@@ -8,6 +8,14 @@
 import Foundation
 import ComposableArchitecture
 
+//extension RankingDetailListFeature.State: Equatable {
+//    static func == (lhs: RankingDetailListFeature.State, rhs: RankingDetailListFeature.State) -> Bool {
+//        lhs.ranking.hashva == rhs.ranking
+//    }
+//    
+//    
+//}
+
 @Reducer
 struct RankingDetailListFeature {
     

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListView.swift
@@ -16,36 +16,23 @@ struct RankingDetailListView: View {
             emptyView
         } else {
             ScrollView {
-                LazyVStack(spacing: 6) {
+                LazyVStack {
                     ForEach(store.ranking, id: \.userID) { data in
                         Button {
                             store.send(.rankCellTapped(data))
                         } label: {
-                            HStack {
-                                Text(String(data.rank))
-                                    .font(.title3)
-                                    .fontWeight(.semibold)
-                                    .foregroundStyle(.ptPoint)
-                                
-                                Text(data.name)
-                                    .font(.title3)
-                                    .fontWeight(.semibold)
-                                    .foregroundStyle(.ptWhite)
-                                    .padding(.leading, 12)
-                                
-                                Spacer()
-                                
-                                Text(data.description())
-                                    .foregroundStyle(.ptLightGray01)
-                            }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 20)
+                            RankingCell(
+                                rank: data.rank,
+                                name: data.name,
+                                description: data.description()
+                            )
                         }
                         .buttonStyle(PTPressedStyle())
                     }
                 }
                 .background(.ptBackground)
                 .padding(.vertical, 20)
+                .padding(.horizontal, 24)
             }
         }
         
@@ -71,6 +58,7 @@ struct RankingDetailListView: View {
             PTButton("운동 하러가기") {
                 store.send(.workoutButtonTapped)
             }
+            .padding(.top, 12)
             
             Spacer()
         }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListView.swift
@@ -10,8 +10,7 @@ import ComposableArchitecture
 
 struct RankingDetailListView: View {
     let store: StoreOf<RankingDetailListFeature>
-    let description: String
-
+    
     var body: some View {
         if store.ranking.isEmpty {
             emptyView
@@ -24,24 +23,29 @@ struct RankingDetailListView: View {
                         } label: {
                             HStack {
                                 Text(String(data.rank))
-                                    .foregroundStyle(.ptLightGray01)
+                                    .font(.title3)
                                     .fontWeight(.semibold)
+                                    .foregroundStyle(.ptPoint)
                                 
                                 Text(data.name)
+                                    .font(.title3)
+                                    .fontWeight(.semibold)
                                     .foregroundStyle(.ptWhite)
+                                    .padding(.leading, 12)
                                 
                                 Spacer()
                                 
-                                Text("\(data.value)\(description)")
+                                Text(data.description())
                                     .foregroundStyle(.ptLightGray01)
                             }
-                            .padding(12)
-                            .background(.ptDarkNavyGray)
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 20)
                         }
+                        .buttonStyle(PTPressedStyle())
                     }
                 }
-                .padding(.all, 20)
+                .background(.ptBackground)
+                .padding(.vertical, 20)
             }
         }
         
@@ -85,7 +89,6 @@ struct RankingDetailListView: View {
                     )
         {
             RankingDetailListFeature()
-        },
-        description: "일째 운동 중"
+        }
     )
 }

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailView.swift
@@ -21,13 +21,18 @@ struct RankingDetailView: View {
             TabView(selection: $store.selectedTab.sending(\.selectTab)) {
                 
                 if let store = store.scope(state: \.consistency, action: \.consistency) {
-                    RankingDetailListView(store: store, description: "일째 운동 중")
+                    RankingDetailListView(store: store)
                         .tag(RankingType.consistency)
                 }
                 
                 if let store = store.scope(state: \.pushUp, action: \.pushUp) {
-                    RankingDetailListView(store: store, description: "회")
+                    RankingDetailListView(store: store)
                         .tag(RankingType.pushUp)
+                }
+                
+                if let store = store.scope(state: \.running, action: \.running) {
+                    RankingDetailListView(store: store)
+                        .tag(RankingType.running)
                 }
             }
             .animation(.default, value: store.selectedTab)
@@ -52,7 +57,7 @@ struct RankingDetailView: View {
 
 #Preview {
     RankingDetailView(
-        store: .init(initialState: RankingDetailFeature.State(.consistency, [.stub1, .stub2, .stub3], [.stub1, .stub2, .stub3])) {
+        store: .init(initialState: RankingDetailFeature.State(.consistency, [.stub1, .stub2, .stub3], [.stub1, .stub2, .stub3], [])) {
             RankingDetailFeature()
         }
     )

--- a/PhysicalTrack/PhysicalTrack/Network/DTO/RankingDTO.swift
+++ b/PhysicalTrack/PhysicalTrack/Network/DTO/RankingDTO.swift
@@ -13,6 +13,10 @@ struct ConsistencyRankingResponse: Decodable, RankingRepresentable {
     let rank: Int
     let value: Int
     
+    func description() -> String {
+        "\(value) 일째 운동 중"
+    }
+    
     enum CodingKeys: String, CodingKey {
         case userID = "userId"
         case name, rank
@@ -26,12 +30,33 @@ struct PushUpRankingResponse: Decodable, RankingRepresentable {
     let rank: Int
     let value: Int
     
+    func description() -> String {
+        "\(value) 회"
+    }
     
     enum CodingKeys: String, CodingKey {
         case userID = "userId"
         case name, rank
         case value = "quantity"
     }
+}
+
+struct RunningRankingResponse: Decodable, RankingRepresentable {
+    let userID: Int
+    let name: String
+    let rank: Int
+    var value: Int { Int(duration) }
+    let duration: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case name, rank, duration
+    }
+    
+    func description() -> String {
+        value.to_분_초
+    }
+    
 }
 
 

--- a/PhysicalTrack/PhysicalTrack/Shared/Extension/Int+.swift
+++ b/PhysicalTrack/PhysicalTrack/Shared/Extension/Int+.swift
@@ -10,9 +10,16 @@ import Foundation
 extension Int {
     
     var to_mmss: String {
-        let hours = Int(self) / 3600
+//        let hours = Int(self) / 3600
         let minutes = Int(self) / 60 % 60
         let seconds = Int(self) % 60
         return String(format: "%02i:%02i", minutes, seconds)
+    }
+    
+    var to_분_초: String {
+//        let hours = Int(self) / 3600
+        let minutes = Int(self) / 60
+        let seconds = Int(self) % 60
+        return String(format: "%i분 %i초", minutes, seconds)
     }
 }

--- a/PhysicalTrack/PhysicalTrack/UI/PTButton/PTButtonStyle.swift
+++ b/PhysicalTrack/PhysicalTrack/UI/PTButton/PTButtonStyle.swift
@@ -95,3 +95,11 @@ struct PTButtonStyle: ButtonStyle {
         
     }
 }
+
+struct PTPressedStyle: ButtonStyle {
+    
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .background(configuration.isPressed ? .ptDarkGray01 : .ptBackground)
+    }
+}


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #63

### ✅ 작업한 내용
- 랭킹 서버 연동
- 랭킹 UI 개선

### ❗️PR Point
- State에 any RankingRepresentable가 있기에 Equatable을 채택할 수 없음.
- Equatable을 채택함으로써 얻는 TestStore의 이점보다 protocol의 다형성이 더 중요하다고 판단

### 📸 스크린샷
![rank](https://github.com/user-attachments/assets/7fd0b55f-38b3-49b2-90d9-ce58655a5b0b)

