### PR TITLE
MainScene 라우팅 방식을 Shared로 변경한다. #66

### DIFF
--- a/PhysicalTrack/PhysicalTrack/Feature/Main/MainFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Main/MainFeature.swift
@@ -30,7 +30,6 @@ struct MainFeature {
         case setting(SettingFeature.Action)
     }
     
-    
     @Dependency(\.hapticClient) var hapticClient
     
     var body: some ReducerOf<Self> {
@@ -40,13 +39,8 @@ struct MainFeature {
                 hapticClient.impact(.light)
                 state.$selectedTab.withLock{ $0 = newValue }
                 return .none
-            case .ranking(.workoutButtonTapped),
-                    .ranking(.path(.element(id: _, action: .rankingDetail(.consistency(.workoutButtonTapped))))),
-                    .ranking(.path(.element(id: _, action: .rankingDetail(.pushUp(.workoutButtonTapped))))):
-                hapticClient.impact(.light)
-                state.$selectedTab.withLock{ $0 = .workout }
-                return .none
             case .setting(.tutorial(.presented(.confirmButtonTapped))):
+                hapticClient.impact(.light)
                 state.$selectedTab.withLock{ $0 = .workout }
                 return .none
             default:

--- a/PhysicalTrack/PhysicalTrack/Feature/Main/MainTabView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Main/MainTabView.swift
@@ -46,7 +46,7 @@ fileprivate struct TabBarItem: View {
     
     private var scene: MainScene
     
-    fileprivate init(_ scene: MainScene) {
+    init(_ scene: MainScene) {
         self.scene = scene
     }
     

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/Ranking/RankingFeature.swift
@@ -21,6 +21,7 @@ struct RankingFeature {
         var pushUpTop3: [PushUpRankingResponse] = []
         var runningTop3: [RunningRankingResponse] = []
         @Presents var alert: AlertState<Action.Alert>?
+        @Shared(.selectedMainScene) var selectedScene: MainScene = .ranking
     }
     
     enum Action {
@@ -64,6 +65,7 @@ struct RankingFeature {
                     }
                 )
             case .workoutButtonTapped:
+                state.$selectedScene.withLock { $0 = .workout }
                 return .none
             case let .rankingDetailButtonTapped(type):
                 state.path.append(.rankingDetail(RankingDetailFeature.State(

--- a/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListFeature.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Ranking/RankingDetail/RankingDetailListFeature.swift
@@ -21,6 +21,7 @@ struct RankingDetailListFeature {
     
     @ObservableState
     struct State {
+        @Shared(.selectedMainScene) var selectedScene: MainScene = .ranking
         var ranking: [any RankingRepresentable] = []
     }
     
@@ -37,6 +38,7 @@ struct RankingDetailListFeature {
             case .rankCellTapped:
                 return .none
             case .workoutButtonTapped:
+                state.$selectedScene.withLock { $0 = .workout }
                 return .run { _ in await dismiss()}
             }
             

--- a/PhysicalTrack/PhysicalTrack/Feature/Workout/WorkoutView.swift
+++ b/PhysicalTrack/PhysicalTrack/Feature/Workout/WorkoutView.swift
@@ -77,13 +77,11 @@ struct WorkoutView: View {
                     store.send(.doneButtonTapped)
                 } label: {
                     HStack(spacing: 12) {
-                        Image(systemName: "play.fill")
-                            .resizable()
-                            .frame(width: 14, height: 14)
-                            .opacity(store.phase == .selectWorkout
-                                     ? 0
-                                     : 1
-                            )
+                        if store.phase == .selectGrade {
+                            Image(systemName: "play.fill")
+                                .resizable()
+                                .frame(width: 14, height: 14)
+                        }
                         
                         Text(store.phase == .selectWorkout
                              ? "완료"


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- closed #66

### ✅ 작업한 내용
- MainFeature에서 손자의 손자뻘 리듀서까지 알아야한다는 단점을 개선하기 위해 Shared로 탭바 스위칭 로직 변경

### ❗️PR Point
- 튜토리얼은 세팅과 홈뷰에 의해 present되며 부모 리듀서에 따라 동작이 달라지기에 shared 방식을 적용하지 않음
